### PR TITLE
CI workflow: Bump node version and add test run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.15] #[8.x, 10.x, 12.x]
+        node-version: [16.3]
 
     steps:
       - uses: actions/checkout@v2
@@ -28,3 +28,4 @@ jobs:
       - run: npm run prettier
       - run: npm run tslint
       - run: npm run tsc
+      - run: npm run test

--- a/.github/workflows/validate-pr-labels.yaml
+++ b/.github/workflows/validate-pr-labels.yaml
@@ -14,5 +14,5 @@ jobs:
       - name: Validate PR labels
         uses: docker://agilepathway/pull-request-label-checker:v1.0.102
         with:
-          any_of: feature,fix,test
+          any_of: feature,feat,fix,test
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr-labels.yaml
+++ b/.github/workflows/validate-pr-labels.yaml
@@ -2,9 +2,6 @@ name: Validate PR labels
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
- CI: Update node version + add test script
- Fix validate-pr-labels workflow: 
  - Explicitly passing GITHUB_TOKEN results in an error, as it's a reserved keyword (the callers GITHUB_TOKEN is implicitly available)
  - 'feature' label (from organisation labels) has been renamed to 'feat'